### PR TITLE
Fix clang compile

### DIFF
--- a/buckygen.c
+++ b/buckygen.c
@@ -247,6 +247,12 @@ typedef struct sp {
 
 SPLAYNODE *worklist = NULL;
 
+/* forward declaration of outputnode */
+int outputnode(SPLAYNODE *liste);
+
+/* forward declaration of comparenodes */
+int comparenodes(unsigned char *canong, int codelength, int type, SPLAYNODE *list);
+
 /* extra arguments to pass to scan procedure */
 #define SCAN_ARGS
 
@@ -940,7 +946,7 @@ int comparenodes(unsigned char *canong, int codelength, int type, SPLAYNODE *lis
 
 /****************************************/
 
-outputnode(SPLAYNODE *liste)
+int outputnode(SPLAYNODE *liste)
  {
     fprintf(stderr, "Error: outputting of nodes not allowed\n");
     exit(1);

--- a/splay.c
+++ b/splay.c
@@ -343,7 +343,7 @@ SPLAY_LOOKUP(SPLAYNODE **to_root  LOOKUP_ARGS)
 
 /*********************************************************************/
 
-static SPLAYNODE*
+static void
 SPLAY_DELETE(SPLAYNODE **to_root, SPLAYNODE *p)
 /* Remove node p from the tree and free it. */
 {


### PR DESCRIPTION
The code does not compile with the latest `clang`, due to use of implicit C language features.
(My version: `Apple clang version 12.0.0 (clang-1200.0.32.29)`)

This PR fixes the compile errors on OSX